### PR TITLE
Added support for user defined custom validation callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Install __Ember-model-validator__ is easy as:
 - [Exclusion](#exclusion)
 - [Numericality](#numericality)
 - [Password*](#password)
+- [CustomValidation](#CustomValidation)
 - ___[Relations](#relations)___
 
 
@@ -201,6 +202,34 @@ The value has to have only numeric values.
     }
   }
 ````
+
+### CustomValidation
+Define a custom callback funciton to validate the model's value. The validation callback is passed 3 values: the key, value, model's scope. return true (or a truthy value) to pass the validation, return false (or falsy value) to fail the validation.
+
+````js
+  validations: {
+    lotteryNumber: {
+      custom: funciton(key, value, model){
+        return model.get('accountBalance') > 1 ? true : false;
+      }
+    }
+  }
+````
+
+this has the same action as above except will use a custom message insetad of the default.
+````js
+  validations: {
+    lotteryNumber: {
+      custom: {
+        validation: funciton(key, value, model){
+          return model.get('accountBalance') > 1 ? true : false;
+        },
+        message: 'You can't win off of good looks and charm.'
+      }
+    }
+  }
+````
+
 
 ### Password
 A set of validators which are especially useful for validating passwords. Be aware that these all of these password-aimed validations will work standalone and carry the same [common options](#common-options) with the rest of the validations. They don't only work for passwords!

--- a/addon/messages.js
+++ b/addon/messages.js
@@ -17,5 +17,6 @@ export default {
   mustContainNumberMessage: 'must include a number',
   mustContainSpecialMessage: 'must include one of these special characters: %@',
   mustContainLowerMessage: 'must include a lower case character',
-  mustContainCapitalMessage: 'must include an upper case character'
+  mustContainCapitalMessage: 'must include an upper case character',
+  customValidationMessage: 'is invalid'
 };

--- a/addon/mixins/model-validator.js
+++ b/addon/mixins/model-validator.js
@@ -46,6 +46,16 @@ export default Ember.Mixin.create({
   },
 
   /**** Validators ****/
+  _validateCustom: function(property, validation){
+    var customValidator = this._getCustomValidator(validation);
+    if (customValidator) {
+      var passedCustomValidation = customValidator(property, this.get(property), this);
+      if (!passedCustomValidation) {
+        this.set('isValidNow', false);
+        this._addToErrors(property, validation.custom, Messages.customValidationMessage);
+      }
+    }
+  },
   _validatePresence: function(property, validation) {
     if (Ember.isBlank(this.get(property))){
       this.set('isValidNow',false);
@@ -227,6 +237,13 @@ export default Ember.Mixin.create({
     if(options.hasOwnProperty('except') && options.except.indexOf(property) !== -1){ validateThis = false; }
     if(options.hasOwnProperty('only') && options.only.indexOf(property) === -1){ validateThis = false; }
     return validateThis;
+  },
+  _getCustomValidator: function(validation){
+    var customValidator = validation.custom;
+    if (this._isThisAnObject(validation.custom) && validation.custom.hasOwnProperty('validation')) {
+      customValidator = validation.custom.validation;
+    } 
+    return typeof customValidator === 'function' ? customValidator : false;
   },
   _getCustomMessage: function(validationObj,defaultMessage) {
     if (this._isThisAnObject(validationObj) && validationObj.hasOwnProperty('message')) {

--- a/tests/dummy/app/models/fake-model.js
+++ b/tests/dummy/app/models/fake-model.js
@@ -74,7 +74,10 @@ export default DS.Model.extend(Validator,{
       mustContainCapital: true,
       mustContainLower: true,
       mustContainNumber: true,
-      mustContainSpecial: true
+      mustContainSpecial: true,
+      custom: function(key, value, _this){
+        return String(value) === String(_this.get('socialSecurity')) ? false : true;
+      }
     },
     mySubdomain:{
       subdomain:{ reserved:['admin','blog'], message: 'this subdomain is super invalid' }
@@ -92,7 +95,14 @@ export default DS.Model.extend(Validator,{
       numericality: { message: 'is not abracadabra' }
     },
     lotteryNumber: {
-      numericality: true
+      numericality: true,
+      custom: { 
+        validation: function(key, value, _this){
+          var favColor = _this.get('favoriteColor');
+          return !!favColor;
+        },
+        message: 'must have a favorite color to play the lotto, duh'
+      }
     },
     acceptConditions: {
       acceptance: true

--- a/tests/unit/mixins/model-validator-test.js
+++ b/tests/unit/mixins/model-validator-test.js
@@ -64,6 +64,12 @@ describe('ModelValidatorMixin', function() {
         expect(model.get('errors').errorsFor('postalCode').mapBy('message')[0][0]).to.equal(Messages.zipCodeMessage);
       });
 
+      it('validates the truthyness of the user custom validation function on `validations.custom`', function(){
+        var model = this.subject({password: 12345});
+        expect(model.validate()).to.equal(false);
+        expect( model.get('errors').errorsFor('password').mapBy('message')[3][0] ).to.equal(Messages.customValidationMessage);
+      });
+
 		  it('validates the email format of the attributes set on `validations.email`', function() {
 	      var model = this.subject({email:'adsfasdf$'});
 	      expect(model.validate()).to.equal(false);
@@ -267,6 +273,14 @@ describe('ModelValidatorMixin', function() {
           });
         });
 
+        it('validates the truthyness of user func for `validations.custom` and use the correct message', function() {
+          var model = this.subject({lotteryNumber: 777});
+          Ember.run(function() {
+            expect(model.validate()).to.equal(false);
+            expect(model.get('errors').errorsFor('lotteryNumber').mapBy('message')[0][0]).to.equal(model.validations.lotteryNumber.custom.message);
+          });
+        });
+
         it('validates the email format of the attributes set on `validations.email` and use the correct message', function() {
           var model = this.subject({bussinessEmail:'adsfasdf$'});
           Ember.run(function() {
@@ -348,7 +362,7 @@ describe('ModelValidatorMixin', function() {
 			describe('when data is corrected after validation', function() {
 
 			  it('it clean the errors', function() {
-		      var model = this.subject({email:'adsfasdf$',name:'Jose Rene',lotteryNumber:124,alibabaNumber:33,legacyCode:'abc', acceptConditions: 1, password: 'k$1hkjGd'});
+		      var model = this.subject({email:'adsfasdf$',name:'Jose Rene',lotteryNumber:124,alibabaNumber:33,legacyCode:'abc', acceptConditions: 1, password: 'k$1hkjGd', favoriteColor: 'FFFFFF', socialSecurity: 12312});
 		      Ember.run(function() {
 		      	expect(model.validate()).to.equal(false);
 		      	model.set('email','rene@higuita.com');
@@ -362,7 +376,7 @@ describe('ModelValidatorMixin', function() {
       describe('when except is passed to `validate`', function() {
 
         it('it validates all the attributes except the ones specifed', function() {
-          var model = this.subject({email:'adsfasdf$',name:'Jose Rene',lotteryNumber:124,alibabaNumber:33,legacyCode:'abc', acceptConditions: 1, password: 'k$1hkjGd'});
+          var model = this.subject({email:'adsfasdf$',name:'Jose Rene',lotteryNumber:124,alibabaNumber:33,legacyCode:'abc', acceptConditions: 1, password: 'k$1hkjGd', favoriteColor: 'FFFFFF', socialSecurity: 12312});
           Ember.run(function() {
             expect(model.validate()).to.equal(false);
             expect(model.validate({except:['email']})).to.equal(true);


### PR DESCRIPTION
This change adds the ability for a user to define a callback to test the property against whatever they want. 

the callback is passed 3 arguments: key, value, and the model's scope. This is awesome because you're able to compare against another property (or properties) on the model. return a truthy value back and it will pass the validation or return a falsy value back to fail the validation. the second example works the exact same way except will use the custom message instead of default.

if the object syntax (2) is used, and the user does not define a `validate` property or the `validate` property is not a function, the validator will not invoke the callback and the validation will pass.

1)
````js
  validations: {
    lotteryNumber: {
      custom: funciton(key, value, model){
        return model.get('accountBalance') > 1 ? true : false;
      }
    }
  }
````

2)
````js
  validations: {
    lotteryNumber: {
      custom: {
        validation: funciton(key, value, model){
          return model.get('accountBalance') > 1 ? true : false;
        },
        message: 'You can't win off of good looks and charm.'
      }
    }
  }
````