### PR TITLE
Allowing to generate custom message with a function that retuns a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Install __Ember-model-validator__ is easy as:
 ##### Common options
 
 All validators accept the following options
-  - `message` _option_. Overwrites the default message.
+  - `message` _option_. Overwrites the default message, it can be a String or a function that returns a string.
   - `errorAs` _option_. Sets the _key_ name to be used when adding errors (default to property name).
 
 ### Presence
@@ -318,6 +318,45 @@ This validator will run the `validate()` function for the specific relation. If 
     }
   }
 ````
+
+## Using function to generate custom message
+
+You can pass a function to generate a more specific error message. Some scenarios are:
+
+* When the message varies depending of the attribute value.
+* When you want to use model attributes in the message.
+
+The message function receives the attribute name, the value of the attribute and the model itself.
+
+**NOTE:** If the function doesn't return a string the default message is going to be used.
+
+### Example
+
+````js
+import DS from 'ember-data';
+import Validator from '../mixins/model-validator';
+
+export default DS.Model.extend(Validator,{
+
+  otherCustomAttribute: DS.attr('number', { defaultValue:  12345 }),
+
+  validations: {
+    otherCustomAttribute: {
+      custom: {
+        validation: function(key, value){
+          return value.toString().length === 5 ? true : false;
+        },
+        message: function(key,value, _this){
+          return key + " must have exactly 5 digits";
+        }
+      }
+    }
+  }
+
+});
+
+````
+
 
 ## Usage
 __Ember-model-validator__ provides a mixin to be included in your models for adding validation support. This mixin can be imported from your app's namespace (e.g. `../mixins/model-validator` in your models).

--- a/addon/mixins/model-validator.js
+++ b/addon/mixins/model-validator.js
@@ -264,18 +264,23 @@ export default Ember.Mixin.create({
     if (Ember.typeOf(validation) === 'object' && validation.hasOwnProperty('validation')) {
       customValidator = validation.validation;
     }
-    return typeof customValidator === 'function' ? customValidator : false;
+    return this._isFunction(customValidator) ? customValidator : false;
   },
-  _getCustomMessage: function(validationObj,defaultMessage) {
+  _getCustomMessage: function(validationObj,defaultMessage, property) {
     if (Ember.typeOf(validationObj) === 'object' && validationObj.hasOwnProperty('message')) {
-      return validationObj.message;
+      if( this._isFunction(validationObj.message )){
+        var msg = validationObj.message.call(property, this.get(property), this);
+        return this._isString( msg ) ? msg : defaultMessage;
+      }else{
+        return validationObj.message;
+      }
     }else{
       return defaultMessage;
     }
   },
   _addToErrors: function(property, validation, defaultMessage) {
     var errors = this.get('validationErrors'),
-        message = this._getCustomMessage(validation, defaultMessage),
+        message = this._getCustomMessage(validation, defaultMessage, property),
         errorAs =  validation.errorAs || property;
     if (!Ember.isArray(errors[errorAs])) {errors[errorAs] = [];}
     if(this.get('addErrors')){errors[errorAs].push([message]);}
@@ -289,5 +294,11 @@ export default Ember.Mixin.create({
               .replace(/([A-Z])/g, ' $1')
               // uppercase the first character
               .replace(/^./, function(str){ return Ember.String.capitalize(str); });
+  },
+  _isFunction: function(func) {
+    return Ember.isEqual(Ember.typeOf(func),'function');
+  },
+  _isString: function(str){
+    return Ember.isEqual(Ember.typeOf(str), 'string');
   }
 });

--- a/tests/dummy/app/models/fake-model.js
+++ b/tests/dummy/app/models/fake-model.js
@@ -36,6 +36,10 @@ export default DS.Model.extend(Validator,{
 
   thing: DS.attr(''),
 
+  otherCustomValidation: DS.attr('number', { defaultValue:  12345 }),
+
+  otherCustomValidationBadMessageFunction: DS.attr('number', { defaultValue:  12345 }),
+
   validations: {
     name: {
       presence: { errorAs:'profile.name' },
@@ -133,6 +137,26 @@ export default DS.Model.extend(Validator,{
     },
     otherFake:{
       relations: ['belongsTo']
+    },
+    otherCustomValidation: {
+      custom: {
+        validation: function(key, value){
+          return value.toString().length === 5 ? true : false;
+        },
+        message: function(key,value, _this){
+          return key + " must have exactly 5 digits";
+        }
+      }
+    },
+    otherCustomValidationBadMessageFunction: {
+      custom: {
+        validation: function(key, value){
+          return value.toString().length === 5 ? true : false;
+        },
+        message: function(key, value, _this){
+          return 12345;
+        }
+      }
     }
   }
 

--- a/tests/unit/mixins/model-validator-test.js
+++ b/tests/unit/mixins/model-validator-test.js
@@ -356,6 +356,30 @@ describe('ModelValidatorMixin', function() {
             expect(model.get('errors').errorsFor('alibabaNumber').mapBy('message')[0][0]).to.equal(model.validations.alibabaNumber.numericality.message);
           });
         });
+
+        describe('When custom message is a function', function(){
+
+          describe('and function returns a string',function(){
+            it('set error message using the function return', function(){
+              var model = this.subject({otherCustomValidation: 123456 });
+              Ember.run(function() {
+                expect(model.validate()).to.equal(false);
+                expect(model.get('errors').errorsFor('otherCustomValidation').mapBy('message')[0][0]).to
+                  .equal(model.validations.otherCustomValidation.custom.message.call('otherCustomValidation', model.get('otherCustomValidation'), model));
+              });
+            });
+          });
+
+          describe('and function does not return a string', function() {
+            it('set error message to default message', function(){
+              var model = this.subject({otherCustomValidationBadMessageFunction: 123456 });
+              Ember.run(function() {
+                expect(model.validate()).to.equal(false);
+                expect(model.get('errors').errorsFor('otherCustomValidationBadMessageFunction').mapBy('message')[0][0]).to.equal(Messages.customValidationMessage);
+              });
+            });
+          });
+        });
       });
 
       describe('when errorAs is set', function() {
@@ -426,9 +450,7 @@ describe('ModelValidatorMixin', function() {
             expect(model.validate({only:['email']})).to.equal(true);
           });
         });
-
       });
-
 	  }
 	);
 


### PR DESCRIPTION
@esbanarango I added the option to generate the custom error message using a function, because sometimes you have to generate a message using some model attributes, or something similar.

Example:
=======

A validation checks if a number is between 10 and 20. In the case you want to tell the user:

*  'the number is too small', if the number is lower than 10
*  'the number is too big',  if the number is bigger than 20. 

You have to have a function to check this.

Another case is when you want to include a "constant" of some variable in the message, for example, when you have a "constant" with the range, something like "the number is not within [10...20]"
