### PR TITLE
Add allow blank validation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Install __Ember-model-validator__ is easy as:
 All validators accept the following options
   - `message` _option_. Overwrites the default message, it can be a String or a [function](#using-function-to-generate-custom-message) that returns a string.
   - `errorAs` _option_. Sets the _key_ name to be used when adding errors (default to property name).
+  - `allowBlank` _option_. If set to `true` and the value is blank as defined by [Ember.isBlank](http://emberjs.com/api/#method_isBlank), all other validations for the field are skipped.
 
 ### Presence
 A value is not present if it is empty or a whitespace string. It uses [Ember.isBlank](http://emberjs.com/api/#method_isBlank) method.

--- a/addon/mixins/model-validator.js
+++ b/addon/mixins/model-validator.js
@@ -34,6 +34,9 @@ export default Ember.Mixin.create({
 			for (var validation in validations[property]) {
         if (this._exceptOrOnly(property,options)) {
           var validationName = Ember.String.capitalize(validation);
+          if (Ember.get(validations[property], Ember.String.camelize(validationName) + '.allowBlank') && Ember.isBlank(this.get(property))) {
+            continue;
+          }
           this[`_validate${validationName}`](property, validations[property]);
         }
 			}

--- a/addon/mixins/model-validator.js
+++ b/addon/mixins/model-validator.js
@@ -34,7 +34,7 @@ export default Ember.Mixin.create({
 			for (var validation in validations[property]) {
         if (this._exceptOrOnly(property,options)) {
           var validationName = Ember.String.capitalize(validation);
-          if (Ember.get(validations[property], Ember.String.camelize(validationName) + '.allowBlank') && Ember.isBlank(this.get(property))) {
+          if (Ember.get(validations[property], validation + '.allowBlank') && Ember.isBlank(this.get(property))) {
             continue;
           }
           this[`_validate${validationName}`](property, validations[property]);

--- a/tests/dummy/app/models/fake-model.js
+++ b/tests/dummy/app/models/fake-model.js
@@ -23,6 +23,7 @@ export default DS.Model.extend(Validator,{
   aTenNumber: DS.attr('number', {defaultValue: 10}),
   anOddNumber: DS.attr('number', {defaultValue: 3}),
   anEvenNumber: DS.attr('number', {defaultValue: 2}),
+  anOptionalNumber: DS.attr('number', {defaultValue: null}),
   acceptConditions: DS.attr('boolean', {defaultValue: true}),
   socialSecurity: DS.attr('number', {defaultValue: 12345}),
   nsaNumber: DS.attr('number', {defaultValue: 1234}),
@@ -133,6 +134,9 @@ export default DS.Model.extend(Validator,{
     },
     anEvenNumber:{
       numericality: {even: true}
+    },
+    anOptionalNumber:{
+      numericality: {onlyInteger: true, allowBlank: true}
     },
     alibabaNumber: {
       numericality: {message: 'is not abracadabra' }

--- a/tests/unit/mixins/model-validator-test.js
+++ b/tests/unit/mixins/model-validator-test.js
@@ -30,6 +30,20 @@ describe('ModelValidatorMixin', function() {
 	      expect(model).to.be.ok;
 	    });
 
+
+      it('skips other validations when optional field is blank', function(){
+        var model = this.subject({anOptionalNumber: null});
+        model.validate();
+        console.log(model.get('errors.messages'));
+        model.validate();
+        expect(model.get('errors').errorsFor('anOptionalNumber').length).to.equal(0);
+      });
+      it('runs remaining validations when optional field is not blank', function(){
+        var model = this.subject({anOptionalNumber: 'abc'});
+        expect(model.validate()).to.equal(false);
+        expect(model.get('errors').errorsFor('anOptionalNumber').mapBy('message')[0][0]).to.equal(Messages.numericalityMessage);
+        expect(model.get('errors').errorsFor('anOptionalNumber').mapBy('message')[1][0]).to.equal(Messages.numericalityOnlyIntegerMessage);
+      });
 		  it('validates the presence of the attributes set on `validations.presence`', function() {
 	      var model = this.subject(),
             errorAs = model.validations.name.presence.errorAs;


### PR DESCRIPTION
Allow optional fields that require validation when set by including `allowBlank: true`  in the validation options 