### PR TITLE
Format validation on a non-mandatory field.

### DIFF
--- a/addon/mixins/model-validator.js
+++ b/addon/mixins/model-validator.js
@@ -131,7 +131,7 @@ export default Ember.Mixin.create({
   },
   _validateFormat(property, validation) {
     let withRegexp = validation.format.with;
-    if (!this.get(property) || String(this.get(property)).match(withRegexp) === null){
+    if (this.get(property) && String(this.get(property)).match(withRegexp) === null){
       this.set('isValidNow',false);
       this._addToErrors(property, validation.format, this.get('messages').formatMessage);
     }

--- a/addon/mixins/model-validator.js
+++ b/addon/mixins/model-validator.js
@@ -131,7 +131,7 @@ export default Ember.Mixin.create({
   },
   _validateFormat(property, validation) {
     let withRegexp = validation.format.with;
-    if (this.get(property) && String(this.get(property)).match(withRegexp) === null){
+    if (!this.get(property) || String(this.get(property)).match(withRegexp) === null){
       this.set('isValidNow',false);
       this._addToErrors(property, validation.format, this.get('messages').formatMessage);
     }

--- a/tests/unit/mixins/model-validator-test.js
+++ b/tests/unit/mixins/model-validator-test.js
@@ -645,6 +645,7 @@ describe('ModelValidatorMixin', function() {
             model.set('passwordConfirmation','k$1hkjGd');
             model.set('email','rene@higuita.com');
             model.set('images','las images');
+            model.set('mainstreamCode','');
             expect(model.validate()).to.equal(false);
             expect(model.validate({except:['asyncModel','otherFake']})).to.equal(true);
           });


### PR DESCRIPTION
Hi @esbanarango ! 

Thanks for this package, it's very helpful !

Currently the format verification also becomes a mandatory field. 
In some cases, we have a regex on a field that is not necessarily required.

So I propose this change :)