### PR TITLE
fix pt-br dateMessage

### DIFF
--- a/addon/messages/pt-br.js
+++ b/addon/messages/pt-br.js
@@ -32,7 +32,7 @@ export default {
   customValidationMessage: 'está inválido',
   matchMessage: 'não corresponde ao formato {match}',
 
-  dateMessage: 'não é uma data inválida',
+  dateMessage: 'não é uma data válida',
   dateBeforeMessage: 'deve ser antes de {date}',
   dateAfterMessage: 'deve ser depois de {date}'
 };


### PR DESCRIPTION
`não é uma data inválida` means "it isn't an invalid date". This double negative confusingly suggests that there isn't anything wrong with the date.

`não é uma data válida` means "it isn't a valid date" which seems the intended message.