### PR TITLE
Add support for filtering specific validations in except/only

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,15 @@ myModel.validate({ addErrors: false });
 // ^ This will validate the model but won't add any errors.
 ```
 
+To target specific validations when using `except`/`only`, pass the validations' names along the attribute's name:
+
+```js
+// This runs all validations, except name's presence and length validations and
+// any email validations.
+// Other name validations are still run.
+myModel.validate({ except: ['name:presence,length', 'email'] });
+```
+
 ### Usage Example
 
 ```js

--- a/tests/unit/mixins/model-validator-test.js
+++ b/tests/unit/mixins/model-validator-test.js
@@ -947,11 +947,11 @@ describe('ModelValidatorMixin', function() {
         run(function() {
           model.set('password', 'k$1hkjGd');
           model.set('passwordConfirmation', 'k$1hkjGd');
-          model.set('email', 'rene@higuita.com');
           model.set('images', 'las images');
           model.set('mainstreamCode', '');
           expect(model.validate()).to.equal(false);
-          expect(model.validate({ except: ['asyncModel', 'otherFake'] })).to.equal(true);
+          expect(model.validate({ except: ['asyncModel', 'otherFake'] })).to.equal(false);
+          expect(model.validate({ except: ['asyncModel', 'otherFake', 'email:email'] })).to.equal(true);
         });
       });
     });
@@ -967,8 +967,9 @@ describe('ModelValidatorMixin', function() {
         });
         run(function() {
           expect(model.validate()).to.equal(false);
-          model.set('email', 'user.name+1@gmail.com');
-          expect(model.validate({ only: ['email'] })).to.equal(true);
+          model.set('email', 'user.name+1');
+          expect(model.validate({ only: ['email'] })).to.equal(false);
+          expect(model.validate({ only: ['email:presence'] })).to.equal(true);
         });
       });
     });


### PR DESCRIPTION
* Created _hasCompositeTag() helper function, responsible for scanning an array of strings (got from except/only) and checking for entries in the format "PROPERTY" or "PROPERTY:VALIDATION_1,VALIDATION_2,...,VALIDATION_N". 
* Edited _exceptOrOnly() to call _hasCompositeTag() to scan for restrictions and exceptions and decide on its return whether some property should be validated or not.
* Edited tests to contemplate scenarios where this featured is relevant.