### PR TITLE
chore: remove `register-version` initializer

### DIFF
--- a/addon/initializers/register-version.js
+++ b/addon/initializers/register-version.js
@@ -1,9 +1,0 @@
-import Ember from 'ember';
-
-export function initialize() {
-  Ember.libraries.register('Ember Model Validator', '4.7.0');
-}
-
-export default {
-  initialize,
-};

--- a/app/initializers/register-version.js
+++ b/app/initializers/register-version.js
@@ -1,1 +1,0 @@
-export { default, initialize } from 'ember-model-validator/initializers/register-version';


### PR DESCRIPTION
Fixes #358

It appears `ember-data` doesn't even log this debug version info anymore.